### PR TITLE
Blacklist the big grad trenches

### DIFF
--- a/source/cba_settings_userconfig/cba_settings.sqf
+++ b/source/cba_settings_userconfig/cba_settings.sqf
@@ -52,3 +52,8 @@ force TFAR_SameLRFrequenciesForSide = true;
 force TFAR_SameSRFrequenciesForSide = true;
 force TFAR_setting_defaultFrequencies_lr_west = "70";
 force TFAR_setting_defaultFrequencies_sr_west = "110,120,130,140,150,160,170,180,190";
+
+force grad_trenches_functions_allowBigEnvelope = false;
+force grad_trenches_functions_allowGigantEnvelope = false;
+force grad_trenches_functions_allowShortEnvelope = false;
+force grad_trenches_functions_allowVehicleEnvelope = false;


### PR DESCRIPTION
When using grad trenches, players will now only be able to dig the small personal trenches, 
effectively preventing players from constructing the Hindenburg line in 20 minutes