### PR TITLE
Add default radio frequencies for OPFOR and INDFOR.

### DIFF
--- a/source/cba_settings_userconfig/cba_settings.sqf
+++ b/source/cba_settings_userconfig/cba_settings.sqf
@@ -61,6 +61,10 @@ force TFAR_SameLRFrequenciesForSide = true;
 force TFAR_SameSRFrequenciesForSide = true;
 force TFAR_setting_defaultFrequencies_lr_west = "70";
 force TFAR_setting_defaultFrequencies_sr_west = "110,120,130,140,150,160,170,180,190";
+force TFAR_setting_defaultFrequencies_lr_east = "70";
+force TFAR_setting_defaultFrequencies_sr_east = "110,120,130,140,150,160,170,180,190";
+force TFAR_setting_defaultFrequencies_lr_independent = "70";
+force TFAR_setting_defaultFrequencies_sr_independent = "110,120,130,140,150,160,170,180,190";
 
 force grad_trenches_functions_allowBigEnvelope = false;
 force grad_trenches_functions_allowGigantEnvelope = false;


### PR DESCRIPTION
This pull request adds lists of default radio frequencies to OPFOR and INDFOR sides in order to provide a quality of life improvement for players.

This does not mean that there will be interference between sides, thanks to TFAR's use of radio encryption codes.
For two sides to be able to talk to each other with their "own" default radios the radio encryption codes needs to be the same between the two sides. That is set through CBA-settings in the mission, which is why I am not adding them here.
Another way is by giving the soldiers of the two sides the same radios, as radio encryption codes are set on a per radio-level.