### PR TITLE
Force default pain effect

### DIFF
--- a/source/cba_settings_userconfig/cba_settings.sqf
+++ b/source/cba_settings_userconfig/cba_settings.sqf
@@ -25,6 +25,7 @@ force ace_medical_menu_allow = 1;
 force ace_medical_allowUnconsciousAnimationOnTreatment = true;
 force ace_medical_playerDamageThreshold = 2;
 force ace_medical_enableUnconsciousnessAI = 0;
+force ace_medical_painEffectType = 1;
 
 force ace_nightvision_disableNVGsWithSights = false;
 force ace_nightvision_fogScaling = 1;


### PR DESCRIPTION
Forces all players to use chromatic abberation (flashing colour bloom) effect instead of the flashing white pain effect.

While it can be argued that a level of freedom for players to choose what they like the most is a good idea this pain effect actually does something besides add a white edge to the screen.