### PR TITLE
Update medical settings to match the ACE3 medical rewrite 

### DIFF
--- a/source/cba_settings_userconfig/cba_settings.sqf
+++ b/source/cba_settings_userconfig/cba_settings.sqf
@@ -21,11 +21,12 @@ force ace_hearing_enableCombatDeafness = false;
 
 force ace_map_mapShowCursorCoordinates = true;
 
-force ace_medical_menu_allow = 1;
-force ace_medical_allowUnconsciousAnimationOnTreatment = true;
-force ace_medical_playerDamageThreshold = 2;
-force ace_medical_enableUnconsciousnessAI = 0;
-force ace_medical_painEffectType = 1;
+force ace_medical_ai_enabledFor = 0;                    // Medical system not enabled for AI
+force ace_medical_feedback_painEffectType = 2;          // Pain effect type is "Chromatic Abberation".
+force ace_medical_gui_enableMedicalMenu = 1;            // Enable medical menu.
+force ace_medical_playerDamageThreshold = 2;            // The amount of damage a player unit can take before dying.
+force ace_medical_statemachine_AIUnconsciousness = 0;   // AI will not go unconscious for any reason, and therefore never enter cardiac arrest.
+force ace_medical_statemachine_fatalInjuriesAI = 0;     // AI will always die instantly.
 
 force ace_nightvision_disableNVGsWithSights = false;
 force ace_nightvision_fogScaling = 1;


### PR DESCRIPTION
This pull request updates the old variable names to match the new ones introduced in the [ACE3 Medical rewrite](https://github.com/acemod/ACE3/releases/tag/v3.13.0).

I wasn't able to find a matching new variable for `ace_medical_allowUnconsciousAnimationOnTreatment `, so it has been left out of this PR.