### PR TITLE
Enable ACE cook off

### DIFF
--- a/source/cba_settings_userconfig/cba_settings.sqf
+++ b/source/cba_settings_userconfig/cba_settings.sqf
@@ -6,10 +6,11 @@ force ace_captives_requireSurrender = 0;
 force ace_common_checkPBOsAction = 0;
 force ace_common_checkPBOsCheckAll = false;
 
-force ace_cookoff_enable = false;
+force ace_cookoff_enable = 1; // ACE 3.13.0 uses settings incorrectly, 1 is AI + Players instead of 2 as it should be
 force ace_cookoff_enableAmmobox = true;
 force ace_cookoff_enableAmmoCookoff = false;
 force ace_cookoff_ammoCookoffDuration = 0.1;
+force ace_cookoff_probabilityCoef = 0.1;
 
 force ace_finger_enabled = true;
 


### PR DESCRIPTION
Cars will not explode but burn instead.
Tanks have a low probability of cooking off.