### PR TITLE
Disable damage from Realistic Driving Terrains mod

### DIFF
--- a/addons/userconfig/cba_settings.sqf
+++ b/addons/userconfig/cba_settings.sqf
@@ -144,6 +144,10 @@ force grad_trenches_functions_allowShortEnvelope = false;
 force grad_trenches_functions_allowVehicleEnvelope = false;
 force grad_trenches_functions_buildFatigueFactor = 0;
 
+force RT_AIdriverlimitspeed = false;
+force RT_damage_T_enableMod = false;
+force RT_damage_W_enableMod = false;
+
 force TFAR_AICanHearPlayer = true;
 force TFAR_AICanHearSpeaker = true;
 force TFAR_objectInterceptionEnabled = false;


### PR DESCRIPTION
Disable wheel and track damage from rough ground when using Realistic Driving Terrains mod